### PR TITLE
Work around dev part dependency failure case

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -63,6 +63,7 @@ parts:
     python-version: python3
     after: [python-augeas, certbot]
     stage-packages: [libaugeas0]
+    python-packages: ['git+https://github.com/certbot/certbot.git']  # workaround for #12
   certbot-nginx:
     plugin: python
     source: certbot
@@ -70,3 +71,4 @@ parts:
     constraints: $SNAPCRAFT_PART_SRC/constraints.txt
     python-version: python3
     after: [certbot]
+    python-packages: ['git+https://github.com/certbot/certbot.git']  # workaround for #12


### PR DESCRIPTION
Get pip to install certbot from its VCS repository directly during the
build of the nginx and apache plugin parts.

This works around issue #12 when it affects the interaction between the
apache or nginx plugin and certbot itself.

It does not work around the case where the same problem occurs in the
interaction between certbot and acme. This looks harder to work around
because pip's VCS URL handling doesn't appear to include a facility to
install from a subdirectory of a git repository and this is where the
acme source is located.